### PR TITLE
Explicitly configure WebClient to use TLSv1.2

### DIFF
--- a/HttpRequestPlugin/HttpRequestPlugin.cs
+++ b/HttpRequestPlugin/HttpRequestPlugin.cs
@@ -94,7 +94,7 @@ namespace HttpRequestPlugin
         {
             try
             {
-                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls13;
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
                 WebClient webClient = new WebClient();
                 foreach (var header in headers)
                 {

--- a/HttpRequestPlugin/HttpRequestPlugin.cs
+++ b/HttpRequestPlugin/HttpRequestPlugin.cs
@@ -94,6 +94,7 @@ namespace HttpRequestPlugin
         {
             try
             {
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls13;
                 WebClient webClient = new WebClient();
                 foreach (var header in headers)
                 {

--- a/HttpRequestPlugin/HttpRequestPlugin.csproj
+++ b/HttpRequestPlugin/HttpRequestPlugin.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>HttpRequestPlugin</RootNamespace>
     <AssemblyName>HttpRequestPlugin</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
@@ -67,6 +67,9 @@
     <PlatformTarget>x86</PlatformTarget>
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Minor change to force the use of TLSv1.2 in the WebClient.

Also updates the target framework to .Net 4.8.